### PR TITLE
Delete unstable Application before rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ cf install-plugin $GOPATH/bin/autopilot
 **On Windows**
 ```
 $ go get github.com/xchapter7x/autopilot
-$ cf install-plugin $env:GOPATH/bin/autopilot.exe
+$ cf install-plugin %GOPATH%\bin\autopilot.exe
 ```
 
 ## usage

--- a/autopilot.go
+++ b/autopilot.go
@@ -43,6 +43,7 @@ func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []str
 					return appRepo.PushApplication(argList)
 				},
 				ReversePrevious: func() error {
+					appRepo.DeleteApplication(appName)
 					return appRepo.RenameApplication(venerableAppName, appName)
 				},
 			},


### PR DESCRIPTION
Hi 

I have the following problem:
Uploading AppName...
FAILED
Error uploading application.
Error performing request: Put https://api.example.com: http: ContentLength=138496 with Body length 0
Renaming app AppName-venerable to AppName in org exa / space dev as dominik...
FAILED
Server error, status code: 400, error code: 100002, message: The app name is taken: AppName
error: Oh no. Something's gone wrong. I've tried to roll back but you should check to see if everything is OK.: Error executing cli core command

So may in case of an error, the "wrong" App should be deleted before rename back to "working" App.

Regards
Dominik
